### PR TITLE
update to lodash 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+* Updated lodash to ^4.0.0

--- a/bin/resin-event-log.js
+++ b/bin/resin-event-log.js
@@ -26,11 +26,11 @@
       if (!mixpanelToken || !subsystem) {
         throw Error('mixpanelToken and subsystem are required to start events interaction.');
       }
-      hooks = _.merge(HOOKS, hooks);
+      hooks = _.defaults(hooks, HOOKS);
       mixpanel = ResinMixpanelClient(mixpanelToken);
       getMixpanelUser = function(userData) {
         var mixpanelUser;
-        mixpanelUser = _.extend({
+        mixpanelUser = _.assign({
           '$email': userData.email,
           '$name': userData.username
         }, userData);

--- a/bower.json
+++ b/bower.json
@@ -14,8 +14,8 @@
     "tests"
   ],
   "dependencies": {
-    "lodash": "~3.*.*",
-    "node-uuid": "~1.*.*",
+    "lodash": "^4.0.0",
+    "node-uuid": "^1.0.0",
     "resin-mixpanel-client": "0.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "resin-event-log",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "",
   "main": "bin/resin-event-log.js",
   "dependencies": {
-    "lodash": "^3.*.*",
+    "lodash": "^4.0.0",
     "resin-mixpanel-client": "0.0.3"
   },
   "devDependencies": {
@@ -14,6 +14,9 @@
     "gulp-coffeelint": "^0.5.0",
     "gulp-util": "^3.0.6",
     "run-sequence": "^1.1.1"
+  },
+  "scripts": {
+    "build": "gulp build"
   },
   "repository": {
     "type": "git",

--- a/src/resin-event-log.coffee
+++ b/src/resin-event-log.coffee
@@ -59,11 +59,11 @@
 		if not mixpanelToken or not subsystem
 			throw Error('mixpanelToken and subsystem are required to start events interaction.')
 
-		hooks = _.merge(HOOKS, hooks)
+		hooks = _.defaults(hooks, HOOKS)
 		mixpanel = ResinMixpanelClient(mixpanelToken)
 
 		getMixpanelUser = (userData) ->
-			mixpanelUser = _.extend
+			mixpanelUser = _.assign
 				'$email': userData.email
 				'$name': userData.username
 			, userData


### PR DESCRIPTION
I want to upgrade the UI to lodash 4 (because `sbvr-types` has upgraded), and this module is a dependency that uses lodash 3 which causes bower to show a warning (and may cause issues).

Page, can you spot any mistakes in my changes? 

Juan, I know this module is a subdependency for the CLI, you should be safe as I bumped the minor version (and major is 0, so npm won't pick this updated without changes on your side). But maybe you'd want to migrate to lodash 4 as well, as version 3 is officially unsupported.