### PR TITLE
Replace lodash with es-toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,12 @@
   },
   "dependencies": {
     "analytics-client": "^2.0.0",
-    "lodash": "^4.17.19"
+    "es-toolkit": "^1.43.0"
   },
   "devDependencies": {
     "@balena/lint": "^5.1.0",
     "@types/chai": "^4.3.3",
     "@types/chai-as-promised": "^7.1.5",
-    "@types/lodash": "^4.14.157",
     "@types/mocha": "^9.1.1",
     "balena-config-karma": "^4.0.0",
     "browserify": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "chai": "^4.3.6",
     "karma": "^5.2.3",
     "mocha": "^10.1.0",
+    "nise": "^6.1.1",
     "querystring": "^0.2.0",
-    "resin-universal-http-mock": "^1.0.1",
+    "sinon": "^21.0.1",
     "typescript": "^4.1.2"
   },
   "scripts": {

--- a/src/adaptors/analytics-client.js
+++ b/src/adaptors/analytics-client.js
@@ -1,5 +1,5 @@
 const { createWebTracker } = require('analytics-client');
-const pick = require('lodash/pick');
+const { pick } = require('es-toolkit');
 
 const ONE_TIME_USER_FIELDS = ['$created'];
 

--- a/src/balena-event-log.js
+++ b/src/balena-event-log.js
@@ -107,7 +107,7 @@ var EVENTS = {
 	deployToBalena: ['open', 'cancel'],
 	invite: ['addInviteOpen', 'create', 'delete', 'accept'],
 	applicationDeviceType: ['select'],
-	applicationName: ['set','suggestedNameClick'],
+	applicationName: ['set', 'suggestedNameClick'],
 };
 
 // TODO: Completely replace the members namespace (which in the orgs era is ambiguous)

--- a/src/balena-event-log.js
+++ b/src/balena-event-log.js
@@ -1,5 +1,4 @@
-var pick = require('lodash/pick');
-var startCase = require('lodash/startCase');
+var { pick, startCase } = require('es-toolkit');
 
 var EVENTS = {
 	user: [

--- a/tests/balena-event-log.spec.js
+++ b/tests/balena-event-log.spec.js
@@ -1,5 +1,4 @@
 var Analytics = require('analytics-client')
-var _ = require('lodash')
 var expect = require('chai').expect
 var mock = require('resin-universal-http-mock')
 
@@ -23,7 +22,7 @@ var FAKE_EVENT = 'x'
 function aggregateMock(mocks) {
 	return {
 		isDone: function () {
-			return _.some(mocks, function (mock) {
+			return mocks.some((mock) => {
 				return mock.isDone()
 			})
 		}
@@ -32,15 +31,14 @@ function aggregateMock(mocks) {
 
 function createAnalyticsBackendMock(options, times) {
 	times = times || 1
-	_.defaults(options, {
+	const optionsWithDefaults = {
 		host: `https://${BALENA_DATA_ENDPOINT}`,
 		method: 'POST',
-		response: 'success'
-	})
+		response: 'success',
+		...options
+	}
 
-	var mocks = _.range(times).map(function () {
-		return mock.create(options)
-	})
+	var mocks = (new Array(times)).fill(mock.create(optionsWithDefaults))
 
 	return aggregateMock(mocks)
 }

--- a/tests/balena-event-log.spec.js
+++ b/tests/balena-event-log.spec.js
@@ -22,7 +22,7 @@ var FAKE_EVENT = 'x'
 function aggregateMock(mocks) {
 	return {
 		isDone: function () {
-			return mocks.some((mock) => {
+			return mocks.some(function (mock) {
 				return mock.isDone()
 			})
 		}
@@ -31,14 +31,15 @@ function aggregateMock(mocks) {
 
 function createAnalyticsBackendMock(options, times) {
 	times = times || 1
-	const optionsWithDefaults = {
+	options = Object.assign({
 		host: `https://${BALENA_DATA_ENDPOINT}`,
 		method: 'POST',
-		response: 'success',
-		...options
-	}
+		response: 'success'
+	}, options)
 
-	var mocks = (new Array(times)).fill(mock.create(optionsWithDefaults))
+	var mocks = Array.from({ length: times }).map(function () {
+		return mock.create(options)
+	})
 
 	return aggregateMock(mocks)
 }

--- a/tests/balena-event-log.spec.js
+++ b/tests/balena-event-log.spec.js
@@ -1,6 +1,7 @@
 var Analytics = require('analytics-client')
 var expect = require('chai').expect
-var mock = require('resin-universal-http-mock')
+var sinon = require('sinon')
+var nise = require('nise')
 
 // NB: set to true to get some extra reporting
 var EXTRA_DEBUG = false
@@ -19,31 +20,6 @@ var FAKE_USER = {
 }
 var FAKE_EVENT = 'x'
 
-function aggregateMock(mocks) {
-	return {
-		isDone: function () {
-			return mocks.some(function (mock) {
-				return mock.isDone()
-			})
-		}
-	}
-}
-
-function createAnalyticsBackendMock(options, times) {
-	times = times || 1
-	options = Object.assign({
-		host: `https://${BALENA_DATA_ENDPOINT}`,
-		method: 'POST',
-		response: 'success'
-	}, options)
-
-	var mocks = Array.from({ length: times }).map(function () {
-		return mock.create(options)
-	})
-
-	return aggregateMock(mocks)
-}
-
 describe('BalenaEventLog', function () {
 
 	let analyticsClient
@@ -51,16 +27,16 @@ describe('BalenaEventLog', function () {
 	let lastUserId = null
 	let lastUserProperties = null
 	let regenerateCalled = false
-
-	before(mock.init)
-	afterEach(mock.reset)
-	after(mock.teardown)
+	let server
 
 	beforeEach(function () {
+		server = nise.fakeServer.create()
+		server.autoRespond = true
+		server.respondWith('POST', `https://${BALENA_DATA_ENDPOINT}`, [
+			200, { 'Content-Type': 'text/plain' }, 'success'
+		])
+
 		// On init, analytics client sends an identify call.
-		createAnalyticsBackendMock({
-			endpoint: '/amplitude',
-		}, 1)
 
 		analyticsClient = Analytics.createClient({
 			projectName: projectId,
@@ -76,7 +52,12 @@ describe('BalenaEventLog', function () {
 		analyticsClient.track = (eventType, props) => trackedEvents.push({eventType, props})
 		analyticsClient.setUserId = (userId) => { lastUserId = userId }
 		analyticsClient.setUserProperties = (props) => { lastUserProperties = props }
+		analyticsClient.regenerateDeviceId = () => { regenerateCalled = true }
 	});
+
+	afterEach(function () {
+		server.restore()
+	})
 
 	describe('Analytics client track', function () {
 		let eventLog
@@ -237,6 +218,51 @@ describe('BalenaEventLog', function () {
 			})
 			const id = await eventLog.getDistinctId()
 			expect(id).to.have.length(1)
+		})
+
+		it('should call setUserId and regenerateDeviceId on logout', async () => {
+			const eventLog = BalenaEventLog({
+				analyticsClient,
+				prefix: SYSTEM,
+			})
+			// Simulate login first to set userId
+			await eventLog.start({ username: 'user', id: 1 })
+			expect(lastUserId).to.equal('user')
+	
+			await eventLog.end()
+			expect(lastUserId).to.be.null
+			expect(regenerateCalled).to.be.true
+		})
+	
+		it('should call setUserId on identify', async () => {
+			const eventLog = BalenaEventLog({
+				analyticsClient,
+				prefix: SYSTEM,
+			})
+			
+			await eventLog.identify({ analyticsClient: 'new-id' })
+			expect(lastUserId).to.equal('new-id')
+		})
+	
+		it('should expose all event namespaces', () => {
+			const eventLog = BalenaEventLog({
+				analyticsClient,
+				prefix: SYSTEM,
+			})
+			const namespaces = [
+				'user', 'apiKey', 'publicKey', 'organization', 'organizationMember',
+				'organizationInvite', 'team', 'teamMember', 'teamApplication',
+				'application', 'block', 'applicationTag', 'applicationMembers',
+				'configVariable', 'environmentVariable', 'serviceVariable', 'device',
+				'release', 'deviceConfigVariable', 'deviceEnvironmentVariable',
+				'deviceServiceVariable', 'deviceTag', 'releaseTag', 'billing',
+				'onboarding', 'gettingStartedGuide', 'page', 'navigation', 'changelog',
+				'actionsSettingsOperations', 'creditsRunwayCalculator', 'members',
+				'deployToBalena', 'invite', 'applicationDeviceType', 'applicationName'
+			]
+			namespaces.forEach(ns => {
+				expect(eventLog).to.have.property(ns)
+			})
 		})
 	})
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
 		"allowJs": true,
 		"checkJs": true,
 		"moduleResolution": "node",
+		"skipLibCheck": true
 	},
 	"include": [
 		"src/*"


### PR DESCRIPTION
Change-type: patch
Fibery: https://balena.fibery.io/Work/Project/We-should-migrate-from-lodash-to-es-toolkit-(UI-CLI-etc.)-1895